### PR TITLE
[BUGFIX] Semantic tags instead of style attributes

### DIFF
--- a/Configuration/TsConfig/Page/rte.ts
+++ b/Configuration/TsConfig/Page/rte.ts
@@ -42,7 +42,7 @@ RTE {
 		removeTagsAndContents =
 
 		// Use CSS formatting when possible
-		useCSS = 1
+		useCSS = 0
 
 		// Processing rules
 		proc {


### PR DESCRIPTION
Setting useCSS = 1 causes text to be wrapped in spans with style attributes instead of strong and em tags being used.
