### PR TITLE
Gruntfile.coffee: adjust path to bower_components

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -2,7 +2,7 @@ module.exports = (grunt) ->
 	grunt.initConfig
 		pkg: grunt.file.readJSON("package.json")
 		dir:
-			components: "Resources/Public/BowerComponents"
+			components: "app/bower_components"
 			build: "Resources/Public/Build"
 			source: "Resources/Public/Source"
 			temp: "Temporary"


### PR DESCRIPTION
In order to work with Grunt, the path needs to be adjusted.